### PR TITLE
jan.papesch/native-loading-fortification

### DIFF
--- a/src/main/java/com/fazecast/jSerialComm/SerialPort.java
+++ b/src/main/java/com/fazecast/jSerialComm/SerialPort.java
@@ -174,10 +174,7 @@ public class SerialPort
 			}
 			else
 			{
-				System.err.println("This operating system is not supported by the jSerialComm library.");
-				libraryPath = libraryFileName = null;
-				architectures = null;
-				System.exit(-1);
+				throw new UnsatisfiedLinkError("This operating system is not supported by the jSerialComm library.");
 			}
 
 			// Load platform-specific binaries for non-Android systems


### PR DESCRIPTION

Fortification of the way the native library is loaded for jSerialComm

1. No System.exit() on unknown operating system
2. Prioritize loading from a hardcoded relative directory - If the directory exists but we are unable to load the library which we expect there, simply fail. (Can be overriden by manually setting the library path via a property)
3. Always check MD5 digest against resource located in jar. (Do not load the library on mismatches - this is not perfect, but together with 2. should be pretty strong.)